### PR TITLE
adds no tracking to prevent entity conflict on the same dbcontext

### DIFF
--- a/src/EfCoreTemporalTable.csproj
+++ b/src/EfCoreTemporalTable.csproj
@@ -15,9 +15,9 @@
     <PackageProjectUrl>https://github.com/glautrou/EfCoreTemporalTable</PackageProjectUrl>
     <PackageIconUrl>https://remixjobs-cache.s3-eu-west-1.amazonaws.com/1600x1200_thumbnail/1562574147-2a3818c7ef8893c42a11319a3501837b.jpeg</PackageIconUrl>
     <RepositoryUrl>https://github.com/glautrou/EfCoreTemporalTable</RepositoryUrl>
-    <AssemblyVersion>1.0.4.0</AssemblyVersion>
-    <FileVersion>1.0.4.0</FileVersion>
-    <Version>1.0.4</Version>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
+    <Version>1.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TemporalExtensions.cs
+++ b/src/TemporalExtensions.cs
@@ -113,7 +113,7 @@ namespace EfCoreTemporalTable
                 .GetTableName<T>();
             var selectSql = $"SELECT * FROM {table}";
             var sql = FormattableStringFactory.Create(selectSql + " FOR SYSTEM_TIME " + temporalCriteria, arguments);
-            return dbSet.FromSqlInterpolated(sql);
+            return dbSet.FromSqlInterpolated(sql).AsNoTracking();
         }
 
         /// <summary>


### PR DESCRIPTION
Adds no tracking. This prevents having to materialize the entity into a new projection....
  